### PR TITLE
pamsm functionality update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pamsm"
-version = "0.1.0"
+version = "0.2.0"
 description = "Rust wrappers around PAM Service Modules functions"
 authors = ["Raphael Catolino <raphael.catolino@gmail.com>"]
 license = "GPLv3"

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,11 @@
 # PAM SM
 
+[![Crates.io version shield](https://img.shields.io/crates/v/pamsm.svg)](https://crates.io/crates/pamsm)
+[![Crates.io license shield](https://img.shields.io/crates/l/pamsm.svg)](https://crates.io/crates/pamsm)
+
 Rust FFI wrapper to implement PAM service modules for Linux.
 
-# Known issues :
-Not all symbols are exported when linking the final module as a ``cdylib``. Linking as a ``dylib`` works fine.
+**[Documentation](https://docs.rs/json/) -**
+**[Cargo](https://crates.io/crates/json) -**
+**[Repository](https://github.com/rcatolino/pam_sm_rust)**
+

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 
 Rust FFI wrapper to implement PAM service modules for Linux.
 
-**[Documentation](https://docs.rs/json/) -**
-**[Cargo](https://crates.io/crates/json) -**
+**[Documentation](https://docs.rs/pamsm/) -**
+**[Cargo](https://crates.io/crates/pamsm) -**
 **[Repository](https://github.com/rcatolino/pam_sm_rust)**
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,11 @@
 //! For example, here is a time based authentication module :
 //!
 //! ```
+//! #[macro_use]
 //! extern crate pamsm;
 //! extern crate time;
 //!
-//! use pamsm::{PamServiceModule, Pam};
-//! use pamsm::pam_raw::{PamFlag, PamError};
+//! use pamsm::{PamServiceModule, Pam, PamFlag, PamError};
 //!
 //! struct PamTime;
 //!
@@ -24,13 +24,7 @@
 //!     }
 //! }
 //!
-//! #[no_mangle]
-//! pub extern "C" fn get_pam_sm() -> Box<PamServiceModule> {
-//!     return Box::new(PamTime {});
-//! }
-//!
-//! pub fn main() {
-//! }
+//! pamsm_init!(Box::new(PamTime));
 //! ```
 
 extern crate libc;
@@ -38,3 +32,5 @@ extern crate libc;
 mod pam;
 pub mod pam_raw;
 pub use self::pam::*;
+pub use self::pam_raw::{PamFlag,PamError};
+

--- a/src/pam_raw.rs
+++ b/src/pam_raw.rs
@@ -31,7 +31,7 @@ macro_rules! i32_enum {
             $ukey = $uvalue,
         }
         impl $name {
-            pub fn new(r: i32) -> $name {
+            fn new(r: i32) -> $name {
                 match r {
                     $( $value => $name::$key, )*
                     _ => $name::$ukey,
@@ -174,7 +174,7 @@ impl fmt::Display for PamError {
     }
 }
 
-pub fn get_user(pamh: PamHandle, prompt: Option<*const c_char>) -> PamResult<Option<*const c_void>> {
+pub fn get_user(pamh: PamHandle, prompt: Option<*const c_char>) -> PamResult<Option<*const c_char>> {
     let mut raw_user : *const c_char = ptr::null();
     let r = unsafe {
         PamError::new(pam_get_user(pamh, &mut raw_user, prompt.unwrap_or(ptr::null())))
@@ -182,7 +182,7 @@ pub fn get_user(pamh: PamHandle, prompt: Option<*const c_char>) -> PamResult<Opt
     if raw_user.is_null() {
         r.to_result(None)
     } else {
-        r.to_result(Some(raw_user as *const c_void))
+        r.to_result(Some(raw_user))
     }
 }
 

--- a/src/pam_raw.rs
+++ b/src/pam_raw.rs
@@ -31,7 +31,7 @@ macro_rules! i32_enum {
             $ukey = $uvalue,
         }
         impl $name {
-            fn new(r: i32) -> $name {
+            pub fn new(r: i32) -> $name {
                 match r {
                     $( $value => $name::$key, )*
                     _ => $name::$ukey,
@@ -171,6 +171,18 @@ impl PamError {
 impl fmt::Display for PamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+pub fn get_user(pamh: PamHandle, prompt: Option<*const c_char>) -> PamResult<Option<*const c_void>> {
+    let mut raw_user : *const c_char = ptr::null();
+    let r = unsafe {
+        PamError::new(pam_get_user(pamh, &mut raw_user, prompt.unwrap_or(ptr::null())))
+    };
+    if raw_user.is_null() {
+        r.to_result(None)
+    } else {
+        r.to_result(Some(raw_user as *const c_void))
     }
 }
 

--- a/test-module/Cargo.toml
+++ b/test-module/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 authors = ["rca <raphael.catolino@gmail.com>"]
 
 [dependencies]
-libc = "^0.2"
 time = "^0.1"
 pamsm = { path = "../" }
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["cdylib"]

--- a/test-module/src/lib.rs
+++ b/test-module/src/lib.rs
@@ -1,16 +1,31 @@
+#[macro_use]
 extern crate pamsm;
 extern crate time;
 
-use pamsm::{PamServiceModule, Pam};
-use pamsm::pam_raw::{PamFlag, PamError};
+use pamsm::{PamServiceModule, Pam, PamFlag, PamError};
 
 struct PamTime;
 
 impl PamServiceModule for PamTime {
     fn authenticate(self: &Self, pamh: Pam, _: PamFlag, args: Vec<String>) -> PamError {
+
+        // If you need login/password here, that works like this:
+        //
+        //  let user = match pamh.get_user(None) {
+        //      Ok(Some(u)) => u,
+        //      Ok(None) => return PamError::USER_UNKNOWN,
+        //      Err(e) => return e,
+        //  };
+		//
+        //  let pass = match pamh.get_authtok(None) {
+        //      Ok(Some(p)) => p,
+        //      Ok(None) => return PamError::AUTH_ERR,
+        //      Err(e) => return e,
+        //  };
+
+        // Only allow authentication when it's 4 AM
         let hour = time::now().tm_hour;
         if hour != 4 {
-            // Only allow authentication when it's 4 AM
             PamError::SUCCESS
         } else {
             PamError::AUTH_ERR
@@ -18,10 +33,5 @@ impl PamServiceModule for PamTime {
     }
 }
 
-#[no_mangle]
-pub extern "C" fn get_pam_sm() -> Box<PamServiceModule> {
-    return Box::new(PamTime {});
-}
+pamsm_init!(Box::new(PamTime));
 
-pub fn main() {
-}


### PR DESCRIPTION
Hello,

thanks for writing this crate! I've used it one of my projects, but I had to add some functionality to get it to work for my use case. I think my patches are generally useful for anyone using this library, hence this pull request.

- crate now works as a regular cdylib
- client code does not need a get_pam_sm() function anymore
- added code to get the username
- added code to get ruser and rhost
- ofcourse documentation updates

please let me know what you think.