### PR TITLE
cargo: move time to a dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,6 @@ categories = ["os::unix-apis", "authentication", "api-bindings"]
 
 [dependencies]
 libc = "^0.2.19"
+
+[dev-dependencies]
 time = "^0.1.37"


### PR DESCRIPTION
`time` is only used for examples, it shouldn't be forwarded as a dependency to consumers of this library.