### PR TITLE
pamsm: add an optional libpam feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
     fi'
 
 script:
-  - cargo test
+  - cargo test --all-features
   - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
-      cargo clippy -- -D warnings;
+      cargo clippy --all-features -- -D warnings;
     fi'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,9 @@ libc = "^0.2.19"
 
 [dev-dependencies]
 time = "^0.1.37"
+
+[features]
+libpam = []
+
+[package.metadata.docs.rs]
+features = ["libpam"]

--- a/readme.md
+++ b/readme.md
@@ -9,3 +9,7 @@ Rust FFI wrapper to implement PAM service modules for Linux.
 **[Cargo](https://crates.io/crates/pamsm) -**
 **[Repository](https://github.com/rcatolino/pam_sm_rust)**
 
+## Features
+
+This crate supports the following optional features:
+ * `libpam`: this enables the extension trait `PamLibExt` and linking against `libpam.so` for its native implementation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,10 @@ extern crate libc;
 
 mod pam;
 mod pam_types;
+#[cfg(feature = "libpam")]
 mod libpam;
 
-pub use pam::{PamServiceModule, Pam, PamFlag, PamError};
+pub use pam::{PamServiceModule, Pam, PamFlag, PamError, PamResult};
+
+#[cfg(feature = "libpam")]
+pub use pam::PamLibExt;


### PR DESCRIPTION
This adds an optional `libpam` feature to enable linking against and
using native C methods from `libpam.so`. As this provides additional
public API and cargo features are additive, this is opt-in and not
on by default.
This also means that consumers of this crate will not get anymore a
link dependency to `libpam.so`, unless they enable this feature.