### PR TITLE
pamsm: clean all remaining clippy warnings

### DIFF
--- a/src/libpam.rs
+++ b/src/libpam.rs
@@ -20,9 +20,8 @@ pub fn get_user(pamh: PamHandle, prompt: Option<*const c_char>) -> PamResult<Opt
     }
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(not_unsafe_ptr_arg_deref))]
-pub fn set_item(pamh: PamHandle, item_type: PamItemType, item: *const c_void) -> PamResult<()> {
-    PamError::new(unsafe { pam_set_item(pamh, item_type as c_int, item) }).to_result(())
+pub(crate) unsafe fn set_item(pamh: PamHandle, item_type: PamItemType, item: *const c_void) -> PamResult<()> {
+    PamError::new(pam_set_item(pamh, item_type as c_int, item)).to_result(())
 }
 
 pub fn get_item(pamh: PamHandle, item_type: PamItemType) -> PamResult<Option<*const c_void>> {

--- a/src/pam.rs
+++ b/src/pam.rs
@@ -82,11 +82,11 @@ impl PamLibExt for Pam {
     }
 
     fn set_authtok(&self, authtok: &CString) -> PamResult<()> {
-        set_item(
+        unsafe { set_item(
             self.0,
             PamItemType::AUTHTOK,
             authtok.as_ptr() as *const c_void,
-        )
+        ) }
     }
 
     fn get_rhost(&self) -> PamResult<Option<&CStr>> {

--- a/src/pam_types.rs
+++ b/src/pam_types.rs
@@ -51,18 +51,17 @@ impl PamResponse {
     }
 }
 
+pub(crate) type PamConvCallback = extern "C" fn(
+    arg1: c_int,
+    arg2: *mut *const PamMessage,
+    arg3: *mut *mut PamResponse,
+    arg4: *mut c_void,
+) -> c_int;
+
 #[repr(C)]
-pub struct PamConv {
-    #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
-    pub cb: Option<
-        extern "C" fn(
-            arg1: c_int,
-            arg2: *mut *const PamMessage,
-            arg3: *mut *mut PamResponse,
-            arg4: *mut c_void,
-        ) -> c_int,
-    >,
-    pub appdata_ptr: *mut c_void,
+pub(crate) struct PamConv {
+    pub(crate) cb: Option<PamConvCallback>,
+    pub(crate) appdata_ptr: *mut c_void,
 }
 
 #[repr(C)]


### PR DESCRIPTION
This introduces some minor code refactoring to address all (previously
silenced) clippy warnings.