### PR TITLE
cargo: pamsm release 0.3.0 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pamsm"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 description = "Rust wrappers around PAM Service Modules functions"
 authors = ["Raphael Catolino <raphael.catolino@gmail.com>"]
 license = "GPL-3.0"
@@ -16,6 +16,15 @@ time = "^0.1.37"
 
 [features]
 libpam = []
+
+[package.metadata.release]
+sign-commit = true
+upload-doc = false
+disable-publish = true
+disable-push = true
+pre-release-commit-message = "cargo: pamsm release {{version}}"
+pro-release-commit-message = "cargo: version bump to {{version}}"
+tag-message = "pams {{version}}"
 
 [package.metadata.docs.rs]
 features = ["libpam"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pamsm"
-version = "0.3.0-alpha.1"
+version = "0.3.0"
 description = "Rust wrappers around PAM Service Modules functions"
 authors = ["Raphael Catolino <raphael.catolino@gmail.com>"]
 license = "GPL-3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pamsm"
-version = "0.3.0"
+version = "0.3.1-alpha.0"
 description = "Rust wrappers around PAM Service Modules functions"
 authors = ["Raphael Catolino <raphael.catolino@gmail.com>"]
 license = "GPL-3.0"


### PR DESCRIPTION
This tags release `0.3.0` and prepares master branch for next development.

It also introduces Cargo manifest metadata for [cargo-release](https://github.com/sunng87/cargo-release).
Further releases can be automated via a simple:
```
$ cargo-release
```