### PR TITLE
pam_types: align ffi types with upstream

### DIFF
--- a/src/pam_types.rs
+++ b/src/pam_types.rs
@@ -9,6 +9,7 @@ use std::ptr::write_volatile;
 
 pub type PamHandle = *const c_uint;
 
+#[repr(C)]
 pub enum PamMsgStyle {
     PROMPT_ECHO_OFF = 1, /* Ask for password without echo */
     PROMPT_ECHO_ON = 2,  /* Ask for password with echo */
@@ -23,7 +24,7 @@ pub enum PamMsgStyle {
 #[repr(C)]
 pub struct PamMessage {
     pub msg_style: PamMsgStyle,
-    pub msg: *const u8,
+    pub msg: *const c_char,
 }
 
 #[repr(C)]


### PR DESCRIPTION
PamMsgStyle is not in C format and breaks when talking to libpam, this
has been corrected by tagging it as #[repr(C)]. Similarly,
PamMessage.msg is listed as *const u8, despite upstream calling it a
char*. This works because they are the same length, but makes rustc have
a hard time. Setting this to what upstream expects, *const c_char, works
as expected.