### PR TITLE
pam: implement conv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,6 @@ homepage = "https://github.com/rcatolino/pam_sm_rust"
 keywords = ["pam", "service", "module", "wrapper", "ffi"]
 categories = ["os::unix-apis", "authentication", "api-bindings"]
 
-[dependencies]
-libc = "^0.2.19"
-
 [dev-dependencies]
 time = "^0.1.37"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,6 @@
 //! pam_module!(PamTime);
 //! ```
 
-extern crate libc;
-
 #[cfg(feature = "libpam")]
 mod libpam;
 mod pam;
@@ -38,3 +36,5 @@ pub use pam::{Pam, PamError, PamFlag, PamResult, PamServiceModule};
 
 #[cfg(feature = "libpam")]
 pub use pam::PamLibExt;
+#[cfg(feature = "libpam")]
+pub use pam_types::PamMsgStyle;


### PR DESCRIPTION
Currently there is no way to do custom communications via PamLibExt.
This change exposes pam_conv's callback as a custom function and
pam_types::PamMsgStyle, since it is a required parameter.

cargo clippy was also run against the repo, so some formatting changes
were made to other files.

Fix #13