### PR TITLE
format and lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,12 +29,12 @@
 
 extern crate libc;
 
-mod pam;
-mod pam_types;
 #[cfg(feature = "libpam")]
 mod libpam;
+mod pam;
+mod pam_types;
 
-pub use pam::{PamServiceModule, Pam, PamFlag, PamError, PamResult};
+pub use pam::{Pam, PamError, PamFlag, PamResult, PamServiceModule};
 
 #[cfg(feature = "libpam")]
 pub use pam::PamLibExt;

--- a/src/libpam.rs
+++ b/src/libpam.rs
@@ -2,16 +2,23 @@
 #![allow(non_camel_case_types)]
 
 use pam::{PamError, PamResult};
-use std::ptr;
 use std::option::Option;
 use std::os::raw::{c_char, c_int, c_void};
+use std::ptr;
 
 use super::pam_types::*;
 
-pub fn get_user(pamh: PamHandle, prompt: Option<*const c_char>) -> PamResult<Option<*const c_char>> {
-    let mut raw_user : *const c_char = ptr::null();
+pub fn get_user(
+    pamh: PamHandle,
+    prompt: Option<*const c_char>,
+) -> PamResult<Option<*const c_char>> {
+    let mut raw_user: *const c_char = ptr::null();
     let r = unsafe {
-        PamError::new(pam_get_user(pamh, &mut raw_user, prompt.unwrap_or(ptr::null())))
+        PamError::new(pam_get_user(
+            pamh,
+            &mut raw_user,
+            prompt.unwrap_or(ptr::null()),
+        ))
     };
     if raw_user.is_null() {
         r.to_result(None)
@@ -20,15 +27,17 @@ pub fn get_user(pamh: PamHandle, prompt: Option<*const c_char>) -> PamResult<Opt
     }
 }
 
-pub(crate) unsafe fn set_item(pamh: PamHandle, item_type: PamItemType, item: *const c_void) -> PamResult<()> {
+pub(crate) unsafe fn set_item(
+    pamh: PamHandle,
+    item_type: PamItemType,
+    item: *const c_void,
+) -> PamResult<()> {
     PamError::new(pam_set_item(pamh, item_type as c_int, item)).to_result(())
 }
 
 pub fn get_item(pamh: PamHandle, item_type: PamItemType) -> PamResult<Option<*const c_void>> {
-    let mut raw_item : *const c_void = ptr::null();
-    let r = unsafe {
-        PamError::new(pam_get_item(pamh, item_type as c_int, &mut raw_item))
-    };
+    let mut raw_item: *const c_void = ptr::null();
+    let r = unsafe { PamError::new(pam_get_item(pamh, item_type as c_int, &mut raw_item)) };
     if raw_item.is_null() {
         r.to_result(None)
     } else {
@@ -36,11 +45,19 @@ pub fn get_item(pamh: PamHandle, item_type: PamItemType) -> PamResult<Option<*co
     }
 }
 
-pub fn get_authtok(pamh: PamHandle, item_type: PamItemType,
-                   prompt: Option<*const c_char>) -> PamResult<Option<*const c_char>> {
-    let mut raw_at : *const c_char = ptr::null();
+pub fn get_authtok(
+    pamh: PamHandle,
+    item_type: PamItemType,
+    prompt: Option<*const c_char>,
+) -> PamResult<Option<*const c_char>> {
+    let mut raw_at: *const c_char = ptr::null();
     let r = unsafe {
-        PamError::new(pam_get_authtok(pamh, item_type as i32, &mut raw_at, prompt.unwrap_or(ptr::null())))
+        PamError::new(pam_get_authtok(
+            pamh,
+            item_type as i32,
+            &mut raw_at,
+            prompt.unwrap_or(ptr::null()),
+        ))
     };
     if raw_at.is_null() {
         r.to_result(None)
@@ -50,7 +67,7 @@ pub fn get_authtok(pamh: PamHandle, item_type: PamItemType,
 }
 
 // Raw functions
-#[link(name="pam")]
+#[link(name = "pam")]
 extern "C" {
     pub fn pam_set_item(pamh: PamHandle, item_type: c_int, item: *const c_void) -> c_int;
     pub fn pam_get_item(pamh: PamHandle, item_type: c_int, item: *mut *const c_void) -> c_int;
@@ -59,16 +76,22 @@ extern "C" {
     pub fn pam_getenv(pamh: PamHandle, name: *const c_char) -> *const c_char;
     pub fn pam_getenvlist(pamh: PamHandle) -> *mut *mut c_char;
 
-    pub fn pam_set_data(pamh: PamHandle,
-                        module_data_name: *const c_char,
-                        data: *mut c_void,
-                        cleanup: Option<extern "C" fn (arg1: PamHandle,
-                                                       arg2: *mut c_void,
-                                                       arg3: c_int)>) -> c_int;
-    pub fn pam_get_data(pamh: PamHandle, module_data_name: *const c_char,
-                        data: *mut *const c_void) -> c_int;
+    pub fn pam_set_data(
+        pamh: PamHandle,
+        module_data_name: *const c_char,
+        data: *mut c_void,
+        cleanup: Option<extern "C" fn(arg1: PamHandle, arg2: *mut c_void, arg3: c_int)>,
+    ) -> c_int;
+    pub fn pam_get_data(
+        pamh: PamHandle,
+        module_data_name: *const c_char,
+        data: *mut *const c_void,
+    ) -> c_int;
     pub fn pam_get_user(pamh: PamHandle, user: *mut *const c_char, prompt: *const c_char) -> c_int;
-    pub fn pam_get_authtok(pamh: PamHandle, item: c_int, authok_ptr: *mut *const c_char,
-		 prompt: *const c_char) -> c_int;
+    pub fn pam_get_authtok(
+        pamh: PamHandle,
+        item: c_int,
+        authok_ptr: *mut *const c_char,
+        prompt: *const c_char,
+    ) -> c_int;
 }
-

--- a/src/pam.rs
+++ b/src/pam.rs
@@ -82,11 +82,13 @@ impl PamLibExt for Pam {
     }
 
     fn set_authtok(&self, authtok: &CString) -> PamResult<()> {
-        unsafe { set_item(
-            self.0,
-            PamItemType::AUTHTOK,
-            authtok.as_ptr() as *const c_void,
-        ) }
+        unsafe {
+            set_item(
+                self.0,
+                PamItemType::AUTHTOK,
+                authtok.as_ptr() as *const c_void,
+            )
+        }
     }
 
     fn get_rhost(&self) -> PamResult<Option<&CStr>> {
@@ -258,9 +260,7 @@ macro_rules! pam_module {
 
                     let mut args = Vec::<String>::with_capacity(argc);
                     for count in 0..(argc as isize) {
-                        match {
-                            CStr::from_ptr(*argv.offset(count) as *const c_char).to_str()
-                        } {
+                        match { CStr::from_ptr(*argv.offset(count) as *const c_char).to_str() } {
                             Ok(s) => args.push(s.to_owned()),
                             Err(_) => return pamsm::PamError::SERVICE_ERR,
                         };


### PR DESCRIPTION
Since it was causing noise and confusion in #15, I have extracted lint
and fmt, via clippy and rustfmt respectively. This should run before
merge on an ongoing basis, and possibly added as an integration test.